### PR TITLE
Lemmas for iterated types

### DIFF
--- a/src/category-theory/groupoids.lagda.md
+++ b/src/category-theory/groupoids.lagda.md
@@ -22,6 +22,7 @@ open import foundation.function-types
 open import foundation.functoriality-dependent-pair-types
 open import foundation.fundamental-theorem-of-identity-types
 open import foundation.identity-types
+open import foundation.telescopes
 open import foundation.propositions
 open import foundation.sets
 open import foundation.type-arithmetic-dependent-pair-types
@@ -151,16 +152,15 @@ module _
             ( λ yp →
               Σ ( Σ (pr1 yp ＝ x) (λ q → (q ∙ pr2 yp) ＝ refl))
                 ( λ ql → (pr2 yp ∙ pr1 ql) ＝ refl))))
-        ( is-contr-Σ
-          ( is-contr-total-path x)
-          ( x , refl)
-          ( is-contr-Σ
+        ( is-contr-iterated-Σ 2
+          ( is-contr-total-path x ,
+            ( x , refl) ,
             ( is-contr-equiv
               ( Σ (x ＝ x) (λ q → q ＝ refl))
               ( equiv-tot
                 ( λ q → equiv-concat (inv right-unit) refl))
-              ( is-contr-total-path' refl))
-            ( refl , refl)
+              ( is-contr-total-path' refl)) ,
+            ( refl , refl) ,
             ( is-proof-irrelevant-is-prop
               ( is-1-type-type-1-Type X x x refl refl)
               ( refl)))))

--- a/src/category-theory/groupoids.lagda.md
+++ b/src/category-theory/groupoids.lagda.md
@@ -22,7 +22,7 @@ open import foundation.function-types
 open import foundation.functoriality-dependent-pair-types
 open import foundation.fundamental-theorem-of-identity-types
 open import foundation.identity-types
-open import foundation.telescopes
+open import foundation.iterated-dependent-pair-types
 open import foundation.propositions
 open import foundation.sets
 open import foundation.type-arithmetic-dependent-pair-types

--- a/src/foundation.lagda.md
+++ b/src/foundation.lagda.md
@@ -141,6 +141,7 @@ open import foundation.fundamental-theorem-of-identity-types public
 open import foundation.global-choice public
 open import foundation.hilberts-epsilon-operators public
 open import foundation.homotopies public
+open import foundation.homotopies-iterated-dependent-product-types public
 open import foundation.homotopy-induction public
 open import foundation.identity-systems public
 open import foundation.identity-truncated-types public

--- a/src/foundation/binary-relations.lagda.md
+++ b/src/foundation/binary-relations.lagda.md
@@ -10,9 +10,9 @@ module foundation.binary-relations where
 open import foundation.dependent-pair-types
 open import foundation.equality-dependent-function-types
 open import foundation.fundamental-theorem-of-identity-types
+open import foundation.iterated-dependent-product-types
 open import foundation.propositions
 open import foundation.subtypes
-open import foundation.telescopes
 open import foundation.univalence
 open import foundation.universe-levels
 

--- a/src/foundation/contractible-types.lagda.md
+++ b/src/foundation/contractible-types.lagda.md
@@ -9,19 +9,19 @@ open import foundation-core.contractible-types public
 <details><summary>Imports</summary>
 
 ```agda
-open import elementary-number-theory.natural-numbers
-
 open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
 open import foundation.function-extensionality
-open import foundation.iterated-dependent-pair-types
 open import foundation.subuniverses
 open import foundation.telescopes
+open import foundation.iterated-dependent-pair-types
+open import foundation.iterated-dependent-product-types
 open import foundation.unit-type
+open import elementary-number-theory.natural-numbers
 open import foundation.universe-levels
 
-open import foundation-core.cartesian-product-types
 open import foundation-core.constant-maps
+open import foundation-core.cartesian-product-types
 open import foundation-core.contractible-maps
 open import foundation-core.equivalences
 open import foundation-core.function-types
@@ -319,4 +319,15 @@ is-contr-iterated-Σ :
 is-contr-iterated-Σ ._ {{base-telescope A}} is-contr-A = is-contr-A
 is-contr-iterated-Σ ._ {{cons-telescope A}} (is-contr-X , x , H) =
   is-contr-Σ is-contr-X x (is-contr-iterated-Σ _ {{A x}} H)
+```
+
+### Iterated products of contractible types is contractible
+
+```agda
+is-contr-iterated-Π :
+  {l : Level} (n : ℕ) {{A : telescope l n}} →
+  apply-base-iterated-Π is-contr A → is-contr (iterated-Π A)
+is-contr-iterated-Π ._ {{base-telescope A}} H = H
+is-contr-iterated-Π ._ {{cons-telescope A}} H =
+  is-contr-Π (λ x → is-contr-iterated-Π _ {{A x}} (H x))
 ```

--- a/src/foundation/contractible-types.lagda.md
+++ b/src/foundation/contractible-types.lagda.md
@@ -9,18 +9,19 @@ open import foundation-core.contractible-types public
 <details><summary>Imports</summary>
 
 ```agda
+open import elementary-number-theory.natural-numbers
+
 open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
 open import foundation.function-extensionality
+open import foundation.iterated-dependent-pair-types
 open import foundation.subuniverses
 open import foundation.telescopes
-open import foundation.iterated-dependent-pair-types
 open import foundation.unit-type
-open import elementary-number-theory.natural-numbers
 open import foundation.universe-levels
 
-open import foundation-core.constant-maps
 open import foundation-core.cartesian-product-types
+open import foundation-core.constant-maps
 open import foundation-core.contractible-maps
 open import foundation-core.equivalences
 open import foundation-core.function-types
@@ -306,7 +307,6 @@ module _
 ### Contractiblity of iterated Σ-types
 
 ```agda
-
 is-contr-Σ-telescope : {l : Level} {n : ℕ} → telescope l n → UU l
 is-contr-Σ-telescope (base-telescope A) = is-contr A
 is-contr-Σ-telescope (cons-telescope A) =
@@ -314,9 +314,9 @@ is-contr-Σ-telescope (cons-telescope A) =
   where X = _
 
 is-contr-iterated-Σ :
-  {l : Level} {n : ℕ} {{A : telescope l n}} →
+  {l : Level} (n : ℕ) {{A : telescope l n}} →
   is-contr-Σ-telescope A → is-contr (iterated-Σ A)
-is-contr-iterated-Σ {{base-telescope A}} is-contr-A = is-contr-A
-is-contr-iterated-Σ {{cons-telescope A}} (is-contr-X , x , H) =
-  is-contr-Σ is-contr-X x (is-contr-iterated-Σ {{A x}} H)
+is-contr-iterated-Σ ._ {{base-telescope A}} is-contr-A = is-contr-A
+is-contr-iterated-Σ ._ {{cons-telescope A}} (is-contr-X , x , H) =
+  is-contr-Σ is-contr-X x (is-contr-iterated-Σ _ {{A x}} H)
 ```

--- a/src/foundation/contractible-types.lagda.md
+++ b/src/foundation/contractible-types.lagda.md
@@ -13,15 +13,10 @@ open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
 open import foundation.function-extensionality
 open import foundation.subuniverses
-open import foundation.telescopes
-open import foundation.iterated-dependent-pair-types
-open import foundation.iterated-dependent-product-types
 open import foundation.unit-type
-open import elementary-number-theory.natural-numbers
 open import foundation.universe-levels
 
 open import foundation-core.constant-maps
-open import foundation-core.cartesian-product-types
 open import foundation-core.contractible-maps
 open import foundation-core.equivalences
 open import foundation-core.function-types
@@ -302,32 +297,4 @@ module _
     {l : Level} (X : UU l) → is-contr A → X ≃ (A → X)
   pr1 (equiv-diagonal-is-contr X H) = const A X
   pr2 (equiv-diagonal-is-contr X H) = is-equiv-diagonal-is-contr H X
-```
-
-### Contractiblity of iterated Σ-types
-
-```agda
-is-contr-Σ-telescope : {l : Level} {n : ℕ} → telescope l n → UU l
-is-contr-Σ-telescope (base-telescope A) = is-contr A
-is-contr-Σ-telescope (cons-telescope A) =
-  (is-contr X) × (Σ X (λ x → is-contr-Σ-telescope (A x)))
-  where X = _
-
-is-contr-iterated-Σ :
-  {l : Level} (n : ℕ) {{A : telescope l n}} →
-  is-contr-Σ-telescope A → is-contr (iterated-Σ A)
-is-contr-iterated-Σ ._ {{base-telescope A}} is-contr-A = is-contr-A
-is-contr-iterated-Σ ._ {{cons-telescope A}} (is-contr-X , x , H) =
-  is-contr-Σ is-contr-X x (is-contr-iterated-Σ _ {{A x}} H)
-```
-
-### Iterated products of contractible types is contractible
-
-```agda
-is-contr-iterated-Π :
-  {l : Level} (n : ℕ) {{A : telescope l n}} →
-  apply-base-iterated-Π is-contr A → is-contr (iterated-Π A)
-is-contr-iterated-Π ._ {{base-telescope A}} H = H
-is-contr-iterated-Π ._ {{cons-telescope A}} H =
-  is-contr-Π (λ x → is-contr-iterated-Π _ {{A x}} (H x))
 ```

--- a/src/foundation/contractible-types.lagda.md
+++ b/src/foundation/contractible-types.lagda.md
@@ -13,10 +13,14 @@ open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
 open import foundation.function-extensionality
 open import foundation.subuniverses
+open import foundation.telescopes
+open import foundation.iterated-dependent-pair-types
 open import foundation.unit-type
+open import elementary-number-theory.natural-numbers
 open import foundation.universe-levels
 
 open import foundation-core.constant-maps
+open import foundation-core.cartesian-product-types
 open import foundation-core.contractible-maps
 open import foundation-core.equivalences
 open import foundation-core.function-types
@@ -297,4 +301,22 @@ module _
     {l : Level} (X : UU l) → is-contr A → X ≃ (A → X)
   pr1 (equiv-diagonal-is-contr X H) = const A X
   pr2 (equiv-diagonal-is-contr X H) = is-equiv-diagonal-is-contr H X
+```
+
+### Contractiblity of iterated Σ-types
+
+```agda
+
+is-contr-Σ-telescope : {l : Level} {n : ℕ} → telescope l n → UU l
+is-contr-Σ-telescope (base-telescope A) = is-contr A
+is-contr-Σ-telescope (cons-telescope A) =
+  (is-contr X) × (Σ X (λ x → is-contr-Σ-telescope (A x)))
+  where X = _
+
+is-contr-iterated-Σ :
+  {l : Level} {n : ℕ} {{A : telescope l n}} →
+  is-contr-Σ-telescope A → is-contr (iterated-Σ A)
+is-contr-iterated-Σ {{base-telescope A}} is-contr-A = is-contr-A
+is-contr-iterated-Σ {{cons-telescope A}} (is-contr-X , x , H) =
+  is-contr-Σ is-contr-X x (is-contr-iterated-Σ {{A x}} H)
 ```

--- a/src/foundation/homotopies-iterated-dependent-product-types.lagda.md
+++ b/src/foundation/homotopies-iterated-dependent-product-types.lagda.md
@@ -16,6 +16,8 @@ open import foundation.iterated-dependent-product-types
 open import foundation.universe-levels
 
 open import foundation-core.contractible-types
+open import foundation-core.equivalences
+open import foundation-core.functoriality-dependent-function-types
 open import foundation-core.identity-types
 open import foundation-core.propositions
 open import foundation-core.truncated-types
@@ -28,7 +30,10 @@ open import foundation-core.truncation-levels
 
 Given an
 [iterated dependent product](foundation.iterated-dependent-product-types.md) we
-can consider [homotopies](foundation-core.homotopies.md) of its elements.
+can consider [homotopies](foundation-core.homotopies.md) of its elements. By
+[function extensionality](foundation.function-extensionality.md), **iterated
+homotopies** are [equivalent](foundation-core.equivalences.md) to
+[identifications](foundation-core.identity-types.md).
 
 ## Definitions
 
@@ -36,7 +41,7 @@ can consider [homotopies](foundation-core.homotopies.md) of its elements.
 
 ```agda
 htpy-iterated-Π :
-  {l : Level} {n : ℕ} {{A : telescope l n}} → (f g : iterated-Π A) → UU l
+  {l : Level} {n : ℕ} {{A : telescope l n}} (f g : iterated-Π A) → UU l
 htpy-iterated-Π {{base-telescope A}} f g = f ＝ g
 htpy-iterated-Π {{cons-telescope A}} f g =
   (x : _) → htpy-iterated-Π {{A x}} (f x) (g x)
@@ -45,10 +50,30 @@ htpy-iterated-Π {{cons-telescope A}} f g =
 ### Iterated function extensionality
 
 ```agda
-iterated-eq-htpy :
+refl-iterated-htpy :
+  {l : Level} (n : ℕ) {{A : telescope l n}}
+  {f : iterated-Π A} → htpy-iterated-Π {{A}} f f
+refl-iterated-htpy .0 {{base-telescope A}} = refl
+refl-iterated-htpy ._ {{cons-telescope A}} x = refl-iterated-htpy _ {{A x}}
+
+iterated-htpy-eq :
+  {l : Level} (n : ℕ) {{A : telescope l n}}
+  {f g : iterated-Π A} → f ＝ g → htpy-iterated-Π {{A}} f g
+iterated-htpy-eq .0 {{base-telescope A}} p = p
+iterated-htpy-eq ._ {{cons-telescope A}} p x =
+  iterated-htpy-eq _ {{A x}} (htpy-eq p x)
+
+eq-iterated-htpy :
   {l : Level} (n : ℕ) {{A : telescope l n}}
   {f g : iterated-Π A} → htpy-iterated-Π {{A}} f g → f ＝ g
-iterated-eq-htpy .0 {{ base-telescope A}} H = H
-iterated-eq-htpy ._ {{cons-telescope A}} H =
-  eq-htpy (λ x → iterated-eq-htpy _ {{A x}} (H x))
+eq-iterated-htpy .0 {{base-telescope A}} H = H
+eq-iterated-htpy ._ {{cons-telescope A}} H =
+  eq-iterated-htpy (λ x → eq-iterated-htpy _ {{A x}} (H x))
+
+equiv-iterated-funext :
+  {l : Level} (n : ℕ) {{A : telescope l n}}
+  {f g : iterated-Π A} → (f ＝ g) ≃ htpy-iterated-Π {{A}} f g
+equiv-iterated-funext .0 {{base-telescope A}} = id-equiv
+equiv-iterated-funext ._ {{cons-telescope A}} =
+  equiv-Π-equiv-family (λ x → equiv-iterated-funext _ {{A x}}) ∘e equiv-funext
 ```

--- a/src/foundation/homotopies-iterated-dependent-product-types.lagda.md
+++ b/src/foundation/homotopies-iterated-dependent-product-types.lagda.md
@@ -77,3 +77,8 @@ equiv-iterated-funext .0 {{base-telescope A}} = id-equiv
 equiv-iterated-funext ._ {{cons-telescope A}} =
   equiv-Π-equiv-family (λ x → equiv-iterated-funext _ {{A x}}) ∘e equiv-funext
 ```
+
+## See also
+
+- [Binary homotopies](foundation.binary-homotopies.md) for once-iterated
+  homotopies.

--- a/src/foundation/homotopies-iterated-dependent-product-types.lagda.md
+++ b/src/foundation/homotopies-iterated-dependent-product-types.lagda.md
@@ -1,0 +1,54 @@
+# Homotopies in iterated dependent product types
+
+```agda
+module foundation.homotopies-iterated-dependent-product-types where
+
+open import foundation.telescopes public
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import elementary-number-theory.natural-numbers
+
+open import foundation.universe-levels
+open import foundation.iterated-dependent-product-types
+open import foundation.function-extensionality
+
+open import foundation-core.truncated-types
+open import foundation-core.truncation-levels
+open import foundation-core.identity-types
+open import foundation-core.contractible-types
+open import foundation-core.propositions
+```
+
+</details>
+
+## Idea
+
+Given an
+[iterated dependent product](foundation.iterated-dependent-product-types.md) we
+can consider [homotopies](foundation-core.homotopies.md) of its elements.
+
+## Definitions
+
+### Homotopies in iterated dependent products of iterated type families
+
+```agda
+htpy-iterated-Π :
+  {l : Level} {n : ℕ} {{A : telescope l n}} → (f g : iterated-Π A) → UU l
+htpy-iterated-Π {{base-telescope A}} f g = f ＝ g
+htpy-iterated-Π {{cons-telescope A}} f g =
+  (x : _) → htpy-iterated-Π {{A x}} (f x) (g x)
+```
+
+### Iterated function extensionality
+
+```agda
+iterated-eq-htpy :
+  {l : Level} (n : ℕ) {{A : telescope l n}}
+  {f g : iterated-Π A} → htpy-iterated-Π {{A}} f g → f ＝ g
+iterated-eq-htpy .0 {{ base-telescope A}} H = H
+iterated-eq-htpy ._ {{cons-telescope A}} H =
+  eq-htpy (λ x → iterated-eq-htpy _ {{A x}} (H x))
+```

--- a/src/foundation/homotopies-iterated-dependent-product-types.lagda.md
+++ b/src/foundation/homotopies-iterated-dependent-product-types.lagda.md
@@ -40,11 +40,11 @@ homotopies** are [equivalent](foundation-core.equivalences.md) to
 ### Homotopies in iterated dependent products of iterated type families
 
 ```agda
-htpy-iterated-Π :
+iterated-htpy :
   {l : Level} {n : ℕ} {{A : telescope l n}} (f g : iterated-Π A) → UU l
-htpy-iterated-Π {{base-telescope A}} f g = f ＝ g
-htpy-iterated-Π {{cons-telescope A}} f g =
-  (x : _) → htpy-iterated-Π {{A x}} (f x) (g x)
+iterated-htpy {{base-telescope A}} f g = f ＝ g
+iterated-htpy {{cons-telescope A}} f g =
+  (x : _) → iterated-htpy {{A x}} (f x) (g x)
 ```
 
 ### Iterated function extensionality
@@ -52,27 +52,27 @@ htpy-iterated-Π {{cons-telescope A}} f g =
 ```agda
 refl-iterated-htpy :
   {l : Level} (n : ℕ) {{A : telescope l n}}
-  {f : iterated-Π A} → htpy-iterated-Π {{A}} f f
+  {f : iterated-Π A} → iterated-htpy {{A}} f f
 refl-iterated-htpy .0 {{base-telescope A}} = refl
 refl-iterated-htpy ._ {{cons-telescope A}} x = refl-iterated-htpy _ {{A x}}
 
 iterated-htpy-eq :
   {l : Level} (n : ℕ) {{A : telescope l n}}
-  {f g : iterated-Π A} → f ＝ g → htpy-iterated-Π {{A}} f g
+  {f g : iterated-Π A} → f ＝ g → iterated-htpy {{A}} f g
 iterated-htpy-eq .0 {{base-telescope A}} p = p
 iterated-htpy-eq ._ {{cons-telescope A}} p x =
   iterated-htpy-eq _ {{A x}} (htpy-eq p x)
 
 eq-iterated-htpy :
   {l : Level} (n : ℕ) {{A : telescope l n}}
-  {f g : iterated-Π A} → htpy-iterated-Π {{A}} f g → f ＝ g
+  {f g : iterated-Π A} → iterated-htpy {{A}} f g → f ＝ g
 eq-iterated-htpy .0 {{base-telescope A}} H = H
 eq-iterated-htpy ._ {{cons-telescope A}} H =
   eq-htpy (λ x → eq-iterated-htpy _ {{A x}} (H x))
 
 equiv-iterated-funext :
   {l : Level} (n : ℕ) {{A : telescope l n}}
-  {f g : iterated-Π A} → (f ＝ g) ≃ htpy-iterated-Π {{A}} f g
+  {f g : iterated-Π A} → (f ＝ g) ≃ iterated-htpy {{A}} f g
 equiv-iterated-funext .0 {{base-telescope A}} = id-equiv
 equiv-iterated-funext ._ {{cons-telescope A}} =
   equiv-Π-equiv-family (λ x → equiv-iterated-funext _ {{A x}}) ∘e equiv-funext

--- a/src/foundation/homotopies-iterated-dependent-product-types.lagda.md
+++ b/src/foundation/homotopies-iterated-dependent-product-types.lagda.md
@@ -11,15 +11,15 @@ open import foundation.telescopes public
 ```agda
 open import elementary-number-theory.natural-numbers
 
-open import foundation.universe-levels
-open import foundation.iterated-dependent-product-types
 open import foundation.function-extensionality
+open import foundation.iterated-dependent-product-types
+open import foundation.universe-levels
 
+open import foundation-core.contractible-types
+open import foundation-core.identity-types
+open import foundation-core.propositions
 open import foundation-core.truncated-types
 open import foundation-core.truncation-levels
-open import foundation-core.identity-types
-open import foundation-core.contractible-types
-open import foundation-core.propositions
 ```
 
 </details>

--- a/src/foundation/homotopies-iterated-dependent-product-types.lagda.md
+++ b/src/foundation/homotopies-iterated-dependent-product-types.lagda.md
@@ -16,10 +16,10 @@ open import foundation.iterated-dependent-product-types
 open import foundation.universe-levels
 
 open import foundation-core.contractible-types
-open import foundation-core.equivalences
-open import foundation-core.functoriality-dependent-function-types
 open import foundation-core.identity-types
+open import foundation-core.functoriality-dependent-function-types
 open import foundation-core.propositions
+open import foundation-core.equivalences
 open import foundation-core.truncated-types
 open import foundation-core.truncation-levels
 ```
@@ -68,7 +68,7 @@ eq-iterated-htpy :
   {f g : iterated-Π A} → htpy-iterated-Π {{A}} f g → f ＝ g
 eq-iterated-htpy .0 {{base-telescope A}} H = H
 eq-iterated-htpy ._ {{cons-telescope A}} H =
-  eq-iterated-htpy (λ x → eq-iterated-htpy _ {{A x}} (H x))
+  eq-htpy (λ x → eq-iterated-htpy _ {{A x}} (H x))
 
 equiv-iterated-funext :
   {l : Level} (n : ℕ) {{A : telescope l n}}

--- a/src/foundation/homotopies-iterated-dependent-product-types.lagda.md
+++ b/src/foundation/homotopies-iterated-dependent-product-types.lagda.md
@@ -16,10 +16,10 @@ open import foundation.iterated-dependent-product-types
 open import foundation.universe-levels
 
 open import foundation-core.contractible-types
-open import foundation-core.identity-types
-open import foundation-core.functoriality-dependent-function-types
-open import foundation-core.propositions
 open import foundation-core.equivalences
+open import foundation-core.functoriality-dependent-function-types
+open import foundation-core.identity-types
+open import foundation-core.propositions
 open import foundation-core.truncated-types
 open import foundation-core.truncation-levels
 ```

--- a/src/foundation/iterated-dependent-pair-types.lagda.md
+++ b/src/foundation/iterated-dependent-pair-types.lagda.md
@@ -96,3 +96,7 @@ is-contr-iterated-Σ ._ {{base-telescope A}} is-contr-A = is-contr-A
 is-contr-iterated-Σ ._ {{cons-telescope A}} (is-contr-X , x , H) =
   is-contr-Σ is-contr-X x (is-contr-iterated-Σ _ {{A x}} H)
 ```
+
+## See also
+
+- [Iterated Π-types](foundation.iterated-dependent-product-types.md)

--- a/src/foundation/iterated-dependent-pair-types.lagda.md
+++ b/src/foundation/iterated-dependent-pair-types.lagda.md
@@ -2,6 +2,8 @@
 
 ```agda
 module foundation.iterated-dependent-pair-types where
+
+open import foundation.telescopes public
 ```
 
 <details><summary>Imports</summary>
@@ -10,8 +12,10 @@ module foundation.iterated-dependent-pair-types where
 open import elementary-number-theory.natural-numbers
 
 open import foundation.dependent-pair-types
-open import foundation.telescopes
 open import foundation.universe-levels
+
+open import foundation-core.cartesian-product-types
+open import foundation-core.contractible-types
 ```
 
 </details>
@@ -72,4 +76,23 @@ iterated-pair :
 iterated-pair (base-iterated-element x) = x
 pr1 (iterated-pair (cons-iterated-element y a)) = y
 pr2 (iterated-pair (cons-iterated-element y a)) = iterated-pair a
+```
+
+## Properties
+
+### Contractiblity of iterated Σ-types
+
+```agda
+is-contr-Σ-telescope : {l : Level} {n : ℕ} → telescope l n → UU l
+is-contr-Σ-telescope (base-telescope A) = is-contr A
+is-contr-Σ-telescope (cons-telescope A) =
+  (is-contr X) × (Σ X (λ x → is-contr-Σ-telescope (A x)))
+  where X = _
+
+is-contr-iterated-Σ :
+  {l : Level} (n : ℕ) {{A : telescope l n}} →
+  is-contr-Σ-telescope A → is-contr (iterated-Σ A)
+is-contr-iterated-Σ ._ {{base-telescope A}} is-contr-A = is-contr-A
+is-contr-iterated-Σ ._ {{cons-telescope A}} (is-contr-X , x , H) =
+  is-contr-Σ is-contr-X x (is-contr-iterated-Σ _ {{A x}} H)
 ```

--- a/src/foundation/iterated-dependent-product-types.lagda.md
+++ b/src/foundation/iterated-dependent-product-types.lagda.md
@@ -13,6 +13,8 @@ open import elementary-number-theory.natural-numbers
 
 open import foundation.universe-levels
 
+open import foundation-core.truncated-types
+open import foundation-core.truncation-levels
 open import foundation-core.contractible-types
 open import foundation-core.propositions
 ```
@@ -90,15 +92,29 @@ apply-codomain-iterated-Π P A = iterated-Π (apply-base-telescope P A)
 
 ## Properties
 
+### If a dependent product satisfies a property if its codomain does, then iterated dependent products satisfy that property if the codomain does
+
+```agda
+section-iterated-Π-section-Π-section-codomain :
+  (P : {l : Level} → UU l → UU l) →
+  ( {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
+    ((x : A) → P (B x)) → P ((x : A) → B x)) →
+  {l : Level} (n : ℕ) {{A : telescope l n}} →
+  apply-codomain-iterated-Π P A → P (iterated-Π A)
+section-iterated-Π-section-Π-section-codomain P f ._ {{base-telescope A}} H =
+  H
+section-iterated-Π-section-Π-section-codomain P f ._ {{cons-telescope A}} H =
+  f (λ x → section-iterated-Π-section-Π-section-codomain P f _ {{A x}} (H x))
+```
+
 ### Iterated products of contractible types is contractible
 
 ```agda
 is-contr-iterated-Π :
   {l : Level} (n : ℕ) {{A : telescope l n}} →
   apply-codomain-iterated-Π is-contr A → is-contr (iterated-Π A)
-is-contr-iterated-Π ._ {{base-telescope A}} H = H
-is-contr-iterated-Π ._ {{cons-telescope A}} H =
-  is-contr-Π (λ x → is-contr-iterated-Π _ {{A x}} (H x))
+is-contr-iterated-Π =
+  section-iterated-Π-section-Π-section-codomain is-contr is-contr-Π
 ```
 
 ### Iterated products of propositions are propositions
@@ -107,7 +123,16 @@ is-contr-iterated-Π ._ {{cons-telescope A}} H =
 is-prop-iterated-Π :
   {l : Level} (n : ℕ) {{A : telescope l n}} →
   apply-codomain-iterated-Π is-prop A → is-prop (iterated-Π A)
-is-prop-iterated-Π ._ {{base-telescope A}} H = H
-is-prop-iterated-Π ._ {{cons-telescope A}} H =
-  is-prop-Π (λ x → is-prop-iterated-Π _ {{A x}} (H x))
+is-prop-iterated-Π =
+  section-iterated-Π-section-Π-section-codomain is-prop is-prop-Π
+```
+
+### Iterated products of truncated types are truncated
+
+```agda
+is-trunc-iterated-Π :
+  {l : Level} (k : 𝕋) (n : ℕ) {{A : telescope l n}} →
+  apply-codomain-iterated-Π (is-trunc k) A → is-trunc k (iterated-Π A)
+is-trunc-iterated-Π k =
+  section-iterated-Π-section-Π-section-codomain (is-trunc k) (is-trunc-Π k)
 ```

--- a/src/foundation/iterated-dependent-product-types.lagda.md
+++ b/src/foundation/iterated-dependent-product-types.lagda.md
@@ -13,10 +13,10 @@ open import elementary-number-theory.natural-numbers
 
 open import foundation.universe-levels
 
-open import foundation-core.truncated-types
-open import foundation-core.truncation-levels
 open import foundation-core.contractible-types
 open import foundation-core.propositions
+open import foundation-core.truncated-types
+open import foundation-core.truncation-levels
 ```
 
 </details>

--- a/src/foundation/iterated-dependent-product-types.lagda.md
+++ b/src/foundation/iterated-dependent-product-types.lagda.md
@@ -2,6 +2,8 @@
 
 ```agda
 module foundation.iterated-dependent-product-types where
+
+open import foundation.telescopes public
 ```
 
 <details><summary>Imports</summary>
@@ -9,8 +11,10 @@ module foundation.iterated-dependent-product-types where
 ```agda
 open import elementary-number-theory.natural-numbers
 
-open import foundation.telescopes
 open import foundation.universe-levels
+
+open import foundation-core.contractible-types
+open import foundation-core.propositions
 ```
 
 </details>
@@ -84,4 +88,28 @@ apply-base-iterated-Π :
 apply-base-iterated-Π P (base-telescope A) = P A
 apply-base-iterated-Π P (cons-telescope A) =
   (x : _) → apply-base-iterated-Π P (A x)
+```
+
+## Properties
+
+### Iterated products of contractible types is contractible
+
+```agda
+is-contr-iterated-Π :
+  {l : Level} (n : ℕ) {{A : telescope l n}} →
+  apply-base-iterated-Π is-contr A → is-contr (iterated-Π A)
+is-contr-iterated-Π ._ {{base-telescope A}} H = H
+is-contr-iterated-Π ._ {{cons-telescope A}} H =
+  is-contr-Π (λ x → is-contr-iterated-Π _ {{A x}} (H x))
+```
+
+### Iterated products of propositions are propositions
+
+```agda
+is-prop-iterated-Π :
+  {l : Level} (n : ℕ) {{A : telescope l n}} →
+  apply-base-iterated-Π is-prop A → is-prop (iterated-Π A)
+is-prop-iterated-Π ._ {{base-telescope A}} H = H
+is-prop-iterated-Π ._ {{cons-telescope A}} H =
+  is-prop-Π (λ x → is-prop-iterated-Π _ {{A x}} (H x))
 ```

--- a/src/foundation/iterated-dependent-product-types.lagda.md
+++ b/src/foundation/iterated-dependent-product-types.lagda.md
@@ -78,16 +78,14 @@ iterated-λ (cons-iterated-section f) x = iterated-λ (f x)
 
 ### Transforming iterated products
 
-Given an operation on universes, we can apply it at the base of the iterated
+Given an operation on universes, we can apply it at the codomain of the iterated
 product.
 
 ```agda
-apply-base-iterated-Π :
+apply-codomain-iterated-Π :
   {l1 : Level} {n : ℕ}
   (P : {l : Level} → UU l → UU l) → telescope l1 n → UU l1
-apply-base-iterated-Π P (base-telescope A) = P A
-apply-base-iterated-Π P (cons-telescope A) =
-  (x : _) → apply-base-iterated-Π P (A x)
+apply-codomain-iterated-Π P A = iterated-Π (apply-base-telescope P A)
 ```
 
 ## Properties
@@ -97,7 +95,7 @@ apply-base-iterated-Π P (cons-telescope A) =
 ```agda
 is-contr-iterated-Π :
   {l : Level} (n : ℕ) {{A : telescope l n}} →
-  apply-base-iterated-Π is-contr A → is-contr (iterated-Π A)
+  apply-codomain-iterated-Π is-contr A → is-contr (iterated-Π A)
 is-contr-iterated-Π ._ {{base-telescope A}} H = H
 is-contr-iterated-Π ._ {{cons-telescope A}} H =
   is-contr-Π (λ x → is-contr-iterated-Π _ {{A x}} (H x))
@@ -108,7 +106,7 @@ is-contr-iterated-Π ._ {{cons-telescope A}} H =
 ```agda
 is-prop-iterated-Π :
   {l : Level} (n : ℕ) {{A : telescope l n}} →
-  apply-base-iterated-Π is-prop A → is-prop (iterated-Π A)
+  apply-codomain-iterated-Π is-prop A → is-prop (iterated-Π A)
 is-prop-iterated-Π ._ {{base-telescope A}} H = H
 is-prop-iterated-Π ._ {{cons-telescope A}} H =
   is-prop-Π (λ x → is-prop-iterated-Π _ {{A x}} (H x))

--- a/src/foundation/iterated-dependent-product-types.lagda.md
+++ b/src/foundation/iterated-dependent-product-types.lagda.md
@@ -72,16 +72,16 @@ iterated-λ (base-iterated-section a) = a
 iterated-λ (cons-iterated-section f) x = iterated-λ (f x)
 ```
 
-### Iterated products with transforms
+### Transforming iterated products
 
-Given an operation on universes, we can define iterated products with a
-transform
+Given an operation on universes, we can apply it at the base of the iterated
+product.
 
 ```agda
-transform-iterated-Π :
+apply-base-iterated-Π :
   {l1 : Level} {n : ℕ}
   (P : {l : Level} → UU l → UU l) → telescope l1 n → UU l1
-transform-iterated-Π P (base-telescope A) = P A
-transform-iterated-Π P (cons-telescope A) =
-  (x : _) → transform-iterated-Π P (A x)
+apply-base-iterated-Π P (base-telescope A) = P A
+apply-base-iterated-Π P (cons-telescope A) =
+  (x : _) → apply-base-iterated-Π P (A x)
 ```

--- a/src/foundation/iterated-dependent-product-types.lagda.md
+++ b/src/foundation/iterated-dependent-product-types.lagda.md
@@ -136,3 +136,8 @@ is-trunc-iterated-Π :
 is-trunc-iterated-Π k =
   section-iterated-Π-section-Π-section-codomain (is-trunc k) (is-trunc-Π k)
 ```
+
+## See also
+
+- [Iterated Σ-types](foundation.iterated-dependent-pair-types.md)
+- [Homotopies of iterated Π-types](foundation.homotopies-iterated-dependent-product-types.md)

--- a/src/foundation/iterated-dependent-product-types.lagda.md
+++ b/src/foundation/iterated-dependent-product-types.lagda.md
@@ -53,6 +53,11 @@ iterated-Π :
   {l : Level} {n : ℕ} → telescope l n → UU l
 iterated-Π (base-telescope A) = A
 iterated-Π (cons-telescope A) = (x : _) → iterated-Π (A x)
+
+iterated-implicit-Π :
+  {l : Level} {n : ℕ} → telescope l n → UU l
+iterated-implicit-Π (base-telescope A) = A
+iterated-implicit-Π (cons-telescope A) = {x : _} → iterated-implicit-Π (A x)
 ```
 
 ### Iterated sections of type families
@@ -88,6 +93,12 @@ apply-codomain-iterated-Π :
   {l1 : Level} {n : ℕ}
   (P : {l : Level} → UU l → UU l) → telescope l1 n → UU l1
 apply-codomain-iterated-Π P A = iterated-Π (apply-base-telescope P A)
+
+apply-codomain-iterated-implicit-Π :
+  {l1 : Level} {n : ℕ}
+  (P : {l : Level} → UU l → UU l) → telescope l1 n → UU l1
+apply-codomain-iterated-implicit-Π P A =
+  iterated-implicit-Π (apply-base-telescope P A)
 ```
 
 ## Properties

--- a/src/foundation/iterated-dependent-product-types.lagda.md
+++ b/src/foundation/iterated-dependent-product-types.lagda.md
@@ -71,3 +71,17 @@ iterated-λ :
 iterated-λ (base-iterated-section a) = a
 iterated-λ (cons-iterated-section f) x = iterated-λ (f x)
 ```
+
+### Iterated products with transforms
+
+Given an operation on universes, we can define iterated products with a
+transform
+
+```agda
+transform-iterated-Π :
+  {l1 : Level} {n : ℕ}
+  (P : {l : Level} → UU l → UU l) → telescope l1 n → UU l1
+transform-iterated-Π P (base-telescope A) = P A
+transform-iterated-Π P (cons-telescope A) =
+  (x : _) → transform-iterated-Π P (A x)
+```

--- a/src/foundation/path-split-maps.lagda.md
+++ b/src/foundation/path-split-maps.lagda.md
@@ -12,7 +12,6 @@ open import foundation-core.path-split-maps public
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.equivalences
-open import foundation.telescopes
 open import foundation.iterated-dependent-product-types
 open import foundation.universe-levels
 

--- a/src/foundation/path-split-maps.lagda.md
+++ b/src/foundation/path-split-maps.lagda.md
@@ -9,11 +9,13 @@ open import foundation-core.path-split-maps public
 <details><summary>Imports</summary>
 
 ```agda
+open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.equivalences
+open import foundation.telescopes
+open import foundation.iterated-dependent-product-types
 open import foundation.universe-levels
 
-open import foundation-core.contractible-types
 open import foundation-core.propositions
 ```
 
@@ -36,11 +38,11 @@ module _
           ( is-contr-prod
             ( is-contr-section-is-equiv
               ( is-equiv-is-path-split f is-path-split-f))
-            ( is-contr-Π
-              ( λ x → is-contr-Π
-                ( λ y → is-contr-section-is-equiv
+            ( is-contr-iterated-Π 2
+              ( λ x y →
+                is-contr-section-is-equiv
                   ( is-emb-is-equiv
-                    ( is-equiv-is-path-split f is-path-split-f) x y))))))
+                    ( is-equiv-is-path-split f is-path-split-f) x y)))))
 
   abstract
     is-equiv-is-path-split-is-equiv :

--- a/src/foundation/propositions.lagda.md
+++ b/src/foundation/propositions.lagda.md
@@ -9,11 +9,7 @@ open import foundation-core.propositions public
 <details><summary>Imports</summary>
 
 ```agda
-open import elementary-number-theory.natural-numbers
-
 open import foundation.contractible-types
-open import foundation.iterated-dependent-product-types
-open import foundation.telescopes
 open import foundation.universe-levels
 
 open import foundation-core.retractions
@@ -43,15 +39,4 @@ module _
 
   is-prop-retract-of : A retract-of B → is-prop B → is-prop A
   is-prop-retract-of = is-trunc-retract-of
-```
-
-### Iterated products of propositions are propositions
-
-```agda
-is-prop-iterated-Π :
-  {l : Level} (n : ℕ) {{A : telescope l n}} →
-  apply-base-iterated-Π is-prop A → is-prop (iterated-Π A)
-is-prop-iterated-Π ._ {{base-telescope A}} H = H
-is-prop-iterated-Π ._ {{cons-telescope A}} H =
-  is-prop-Π (λ x → is-prop-iterated-Π _ {{A x}} (H x))
 ```

--- a/src/foundation/propositions.lagda.md
+++ b/src/foundation/propositions.lagda.md
@@ -50,7 +50,7 @@ module _
 ```agda
 is-prop-iterated-Π :
   {l : Level} (n : ℕ) {{A : telescope l n}} →
-  transform-iterated-Π is-prop A → is-prop (iterated-Π A)
+  apply-base-iterated-Π is-prop A → is-prop (iterated-Π A)
 is-prop-iterated-Π ._ {{base-telescope A}} H = H
 is-prop-iterated-Π ._ {{cons-telescope A}} H =
   is-prop-Π (λ x → is-prop-iterated-Π _ {{A x}} (H x))

--- a/src/foundation/propositions.lagda.md
+++ b/src/foundation/propositions.lagda.md
@@ -48,14 +48,9 @@ module _
 ### Iterated products of propositions are propositions
 
 ```agda
-is-prop-telescope :
-  {l : Level} {n : ℕ} → telescope l n → UU l
-is-prop-telescope (base-telescope A) = is-prop A
-is-prop-telescope (cons-telescope A) = (x : _) → is-prop-telescope (A x)
-
 is-prop-iterated-Π :
   {l : Level} (n : ℕ) {{A : telescope l n}} →
-  is-prop-telescope A → is-prop (iterated-Π A)
+  transform-iterated-Π is-prop A → is-prop (iterated-Π A)
 is-prop-iterated-Π ._ {{base-telescope A}} H = H
 is-prop-iterated-Π ._ {{cons-telescope A}} H =
   is-prop-Π (λ x → is-prop-iterated-Π _ {{A x}} (H x))

--- a/src/foundation/telescopes.lagda.md
+++ b/src/foundation/telescopes.lagda.md
@@ -86,23 +86,387 @@ instance
   instance-telescope⁰ {X = X} = base-telescope X
 
   instance-telescope¹ :
-    {l1 lX : Level} {A : UU l1} {X : A → UU lX} → telescope (l1 ⊔ lX) 1
+    { l1 l : Level} {A1 : UU l1} {X : A1 → UU l} → telescope (l1 ⊔ l) 1
   instance-telescope¹ {X = X} =
-    cons-telescope (λ a → instance-telescope⁰ {X = X a})
+    cons-telescope (λ x → instance-telescope⁰ {X = X x})
 
   instance-telescope² :
-    {l1 l2 lX : Level} {A : UU l1} {B : A → UU l2}
-    {X : (a : A) → B a → UU lX} → telescope (l1 ⊔ l2 ⊔ lX) 2
+    { l1 l2 l : Level} {A1 : UU l1} {A2 : A1 → UU l2}
+    { X : (x1 : A1) → A2 x1 → UU l} → telescope (l1 ⊔ l2 ⊔ l) 2
   instance-telescope² {X = X} =
-    cons-telescope (λ a → instance-telescope¹ {X = X a})
+    cons-telescope (λ x → instance-telescope¹ {X = X x})
 
   instance-telescope³ :
-    {l1 l2 l3 l4 : Level}
-    {A : UU l1} {B : A → UU l2} {C : (a : A) → B a → UU l3}
-    {X : (a : A) → (b : B a) → C a b → UU l4} →
-    telescope (l1 ⊔ l2 ⊔ l3 ⊔ l4) 3
+    { l1 l2 l3 l : Level}
+    { A1 : UU l1} {A2 : A1 → UU l2} {A3 : (x1 : A1) → A2 x1 → UU l3}
+    { X : (x1 : A1) (x2 : A2 x1) (x2 : A3 x1 x2) → UU l} →
+    telescope (l1 ⊔ l2 ⊔ l3 ⊔ l) 3
   instance-telescope³ {X = X} =
-    cons-telescope (λ a → instance-telescope² {X = X a})
+    cons-telescope (λ x → instance-telescope² {X = X x})
+
+  instance-telescope⁴ :
+    { l1 l2 l3 l4 l : Level}
+    { A1 : UU l1} {A2 : A1 → UU l2} {A3 : (x1 : A1) → A2 x1 → UU l3}
+    { A4 : (x1 : A1) (x2 : A2 x1) → A3 x1 x2 → UU l4}
+    { X : (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3) → UU l} →
+    telescope (l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ l) 4
+  instance-telescope⁴ {X = X} =
+    cons-telescope (λ x → instance-telescope³ {X = X x})
+
+  instance-telescope⁵ :
+    { l1 l2 l3 l4 l5 l : Level}
+    { A1 : UU l1} {A2 : A1 → UU l2} {A3 : (x1 : A1) → A2 x1 → UU l3}
+    { A4 : (x1 : A1) (x2 : A2 x1) → A3 x1 x2 → UU l4}
+    { A5 : (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3) → UU l5}
+    { X :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) → UU l} →
+    telescope (l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ l5 ⊔ l) 5
+  instance-telescope⁵ {X = X} =
+    cons-telescope (λ x → instance-telescope⁴ {X = X x})
+
+  instance-telescope⁶ :
+    { l1 l2 l3 l4 l5 l6 l : Level}
+    { A1 : UU l1} {A2 : A1 → UU l2} {A3 : (x1 : A1) → A2 x1 → UU l3}
+    { A4 : (x1 : A1) (x2 : A2 x1) → A3 x1 x2 → UU l4}
+    { A5 : (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3) → UU l5}
+    { A6 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) → UU l6}
+    { X :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5) → UU l} →
+    telescope (l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ l5 ⊔ l6 ⊔ l) 6
+  instance-telescope⁶ {X = X} =
+    cons-telescope (λ x → instance-telescope⁵ {X = X x})
+
+  instance-telescope⁷ :
+    { l1 l2 l3 l4 l5 l6 l7 l : Level}
+    { A1 : UU l1} {A2 : A1 → UU l2} {A3 : (x1 : A1) → A2 x1 → UU l3}
+    { A4 : (x1 : A1) (x2 : A2 x1) → A3 x1 x2 → UU l4}
+    { A5 : (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3) → UU l5}
+    { A6 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) → UU l6}
+    { A7 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5) → UU l7}
+    { X :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) → UU l} →
+    telescope (l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ l5 ⊔ l6 ⊔ l7 ⊔ l) 7
+  instance-telescope⁷ {X = X} =
+    cons-telescope (λ x → instance-telescope⁶ {X = X x})
+
+  instance-telescope⁸ :
+    { l1 l2 l3 l4 l5 l6 l7 l8 l : Level}
+    { A1 : UU l1} {A2 : A1 → UU l2} {A3 : (x1 : A1) → A2 x1 → UU l3}
+    { A4 : (x1 : A1) (x2 : A2 x1) → A3 x1 x2 → UU l4}
+    { A5 : (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3) → UU l5}
+    { A6 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) → UU l6}
+    { A7 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5) → UU l7}
+    { A8 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) → UU l8}
+    { X :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7) → UU l} →
+    telescope (l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ l5 ⊔ l6 ⊔ l7 ⊔ l8 ⊔ l) 8
+  instance-telescope⁸ {X = X} =
+    cons-telescope (λ x → instance-telescope⁷ {X = X x})
+
+  instance-telescope⁹ :
+    { l1 l2 l3 l4 l5 l6 l7 l8 l9 l : Level}
+    { A1 : UU l1} {A2 : A1 → UU l2} {A3 : (x1 : A1) → A2 x1 → UU l3}
+    { A4 : (x1 : A1) (x2 : A2 x1) → A3 x1 x2 → UU l4}
+    { A5 : (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3) → UU l5}
+    { A6 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) → UU l6}
+    { A7 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5) → UU l7}
+    { A8 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) → UU l8}
+    { A9 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7) →
+      UU l9}
+    { X :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) → UU l} →
+    telescope (l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ l5 ⊔ l6 ⊔ l7 ⊔ l8 ⊔ l9 ⊔ l) 9
+  instance-telescope⁹ {X = X} =
+    cons-telescope (λ x → instance-telescope⁸ {X = X x})
+
+  instance-telescope¹⁰ :
+    { l1 l2 l3 l4 l5 l6 l7 l8 l9 l10 l : Level}
+    { A1 : UU l1} {A2 : A1 → UU l2} {A3 : (x1 : A1) → A2 x1 → UU l3}
+    { A4 : (x1 : A1) (x2 : A2 x1) → A3 x1 x2 → UU l4}
+    { A5 : (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3) → UU l5}
+    { A6 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) → UU l6}
+    { A7 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5) → UU l7}
+    { A8 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) → UU l8}
+    { A9 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7) →
+      UU l9}
+    { A10 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) →
+      UU l10}
+    { X :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9) →
+      UU l} →
+    telescope (l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ l5 ⊔ l6 ⊔ l7 ⊔ l8 ⊔ l9 ⊔ l10 ⊔ l) 10
+  instance-telescope¹⁰ {X = X} =
+    cons-telescope (λ x → instance-telescope⁹ {X = X x})
+
+  instance-telescope¹¹ :
+    { l1 l2 l3 l4 l5 l6 l7 l8 l9 l10 l11 l : Level}
+    { A1 : UU l1} {A2 : A1 → UU l2} {A3 : (x1 : A1) → A2 x1 → UU l3}
+    { A4 : (x1 : A1) (x2 : A2 x1) → A3 x1 x2 → UU l4}
+    { A5 : (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3) → UU l5}
+    { A6 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) → UU l6}
+    { A7 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5) → UU l7}
+    { A8 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) → UU l8}
+    { A9 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7) →
+      UU l9}
+    { A10 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) →
+      UU l10}
+    { A11 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9) →
+      UU l11}
+    { X :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10) → UU l} →
+    telescope (l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ l5 ⊔ l6 ⊔ l7 ⊔ l8 ⊔ l9 ⊔ l10 ⊔ l11 ⊔ l) 11
+  instance-telescope¹¹ {X = X} =
+    cons-telescope (λ x → instance-telescope¹⁰ {X = X x})
+
+  instance-telescope¹² :
+    { l1 l2 l3 l4 l5 l6 l7 l8 l9 l10 l11 l12 l : Level}
+    { A1 : UU l1} {A2 : A1 → UU l2} {A3 : (x1 : A1) → A2 x1 → UU l3}
+    { A4 : (x1 : A1) (x2 : A2 x1) → A3 x1 x2 → UU l4}
+    { A5 : (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3) → UU l5}
+    { A6 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) → UU l6}
+    { A7 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5) → UU l7}
+    { A8 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) → UU l8}
+    { A9 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7) →
+      UU l9}
+    { A10 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) →
+      UU l10}
+    { A11 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9) →
+      UU l11}
+    { A12 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10) → UU l12}
+    { X :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11) → UU l} →
+    telescope
+      ( l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ l5 ⊔ l6 ⊔ l7 ⊔ l8 ⊔ l9 ⊔ l10 ⊔ l11 ⊔ l12 ⊔ l)
+      ( 12)
+  instance-telescope¹² {X = X} =
+    cons-telescope (λ x → instance-telescope¹¹ {X = X x})
+
+  instance-telescope¹³ :
+    { l1 l2 l3 l4 l5 l6 l7 l8 l9 l10 l11 l12 l13 l : Level}
+    { A1 : UU l1} {A2 : A1 → UU l2} {A3 : (x1 : A1) → A2 x1 → UU l3}
+    { A4 : (x1 : A1) (x2 : A2 x1) → A3 x1 x2 → UU l4}
+    { A5 : (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3) → UU l5}
+    { A6 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) → UU l6}
+    { A7 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5) → UU l7}
+    { A8 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) → UU l8}
+    { A9 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7) →
+      UU l9}
+    { A10 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) →
+      UU l10}
+    { A11 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9) →
+      UU l11}
+    { A12 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10) → UU l12}
+    { A13 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11) → UU l13}
+    { X :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12) → UU l} →
+    telescope
+      ( l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ l5 ⊔ l6 ⊔ l7 ⊔ l8 ⊔ l9 ⊔ l10 ⊔ l11 ⊔ l12 ⊔ l13 ⊔ l)
+      ( 13)
+  instance-telescope¹³ {X = X} =
+    cons-telescope (λ x → instance-telescope¹² {X = X x})
+
+  instance-telescope¹⁴ :
+    { l1 l2 l3 l4 l5 l6 l7 l8 l9 l10 l11 l12 l13 l14 l : Level}
+    { A1 : UU l1} {A2 : A1 → UU l2} {A3 : (x1 : A1) → A2 x1 → UU l3}
+    { A4 : (x1 : A1) (x2 : A2 x1) → A3 x1 x2 → UU l4}
+    { A5 : (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3) → UU l5}
+    { A6 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) → UU l6}
+    { A7 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5) → UU l7}
+    { A8 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) → UU l8}
+    { A9 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7) →
+      UU l9}
+    { A10 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) →
+      UU l10}
+    { A11 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9) →
+      UU l11}
+    { A12 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10) → UU l12}
+    { A13 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11) → UU l13}
+    { A14 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12) → UU l14}
+    { X :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)
+      (x14 : A14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13) → UU l} →
+    telescope
+      ( l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ l5 ⊔ l6 ⊔ l7 ⊔ l8 ⊔ l9 ⊔ l10 ⊔ l11 ⊔ l12 ⊔ l13 ⊔
+        l14 ⊔ l)
+      ( 14)
+  instance-telescope¹⁴ {X = X} =
+    cons-telescope (λ x → instance-telescope¹³ {X = X x})
 
 instance-telescope : {l : Level} {n : ℕ} → {{telescope l n}} → telescope l n
 instance-telescope {{x}} = x

--- a/src/foundation/telescopes.lagda.md
+++ b/src/foundation/telescopes.lagda.md
@@ -80,6 +80,13 @@ apply-base-telescope P (cons-telescope A) =
 
 ### Inferring telescopes
 
+To get Agda to infer telescopes, we help it along a little using
+[instance arguments](https://agda.readthedocs.io/en/v2.6.3.20230914/language/instance-arguments.html).
+These are a special kind of implicit argument in Agda that are resolved by the
+instance resolution algorithm. We register building blocks for this algorithm to
+use below, i.e. _instances_. Then Agda will attempt to use those to construct
+telescopes of the appropriate kind when asked to.
+
 ```agda
 instance-telescope : {l : Level} {n : ℕ} → {{telescope l n}} → telescope l n
 instance-telescope {{x}} = x

--- a/src/foundation/telescopes.lagda.md
+++ b/src/foundation/telescopes.lagda.md
@@ -867,3 +867,9 @@ instance
   instance-telescope¹⁸ {X = X} =
     cons-telescope (λ x → instance-telescope¹⁷ {X = X x})
 ```
+
+## See also
+
+- [Dependent telescopes](foundation.dependent-telescopes.md)
+- [Iterated Σ-types](foundation.iterated-dependent-pair-types.md)
+- [Iterated Π-types](foundation.iterated-dependent-product-types.md)

--- a/src/foundation/telescopes.lagda.md
+++ b/src/foundation/telescopes.lagda.md
@@ -84,8 +84,10 @@ instance
     cons-telescope (λ a → instance-telescope¹ {X = X a})
 
   instance-telescope³ :
-    {l1 l2 l3 lX : Level} {A : UU l1} {B : A → UU l2} {C : (a : A) → B a → UU l3}
-    {X : (a : A) → (b : B a) → C a b → UU lX} → telescope (l1 ⊔ l2 ⊔ l3 ⊔ lX) 3
+    {l1 l2 l3 l4 : Level}
+    {A : UU l1} {B : A → UU l2} {C : (a : A) → B a → UU l3}
+    {X : (a : A) → (b : B a) → C a b → UU l4} →
+    telescope (l1 ⊔ l2 ⊔ l3 ⊔ l4) 3
   instance-telescope³ {X = X} =
     cons-telescope (λ a → instance-telescope² {X = X a})
 

--- a/src/foundation/telescopes.lagda.md
+++ b/src/foundation/telescopes.lagda.md
@@ -65,6 +65,19 @@ data
 open telescope public
 ```
 
+### Transformations on telescopes
+
+Given an operation on universes, we can apply it at the base of the telescope.
+
+```agda
+apply-base-telescope :
+  {l1 : Level} {n : ℕ}
+  (P : {l : Level} → UU l → UU l) → telescope l1 n → telescope l1 n
+apply-base-telescope P (base-telescope A) = base-telescope (P A)
+apply-base-telescope P (cons-telescope A) =
+  cons-telescope (λ x → apply-base-telescope P (A x))
+```
+
 ### Inferring telescopes
 
 ```agda

--- a/src/foundation/telescopes.lagda.md
+++ b/src/foundation/telescopes.lagda.md
@@ -81,6 +81,9 @@ apply-base-telescope P (cons-telescope A) =
 ### Inferring telescopes
 
 ```agda
+instance-telescope : {l : Level} {n : ℕ} → {{telescope l n}} → telescope l n
+instance-telescope {{x}} = x
+
 instance
   instance-telescope⁰ : {l : Level} {X : UU l} → telescope l 0
   instance-telescope⁰ {X = X} = base-telescope X
@@ -468,6 +471,392 @@ instance
   instance-telescope¹⁴ {X = X} =
     cons-telescope (λ x → instance-telescope¹³ {X = X x})
 
-instance-telescope : {l : Level} {n : ℕ} → {{telescope l n}} → telescope l n
-instance-telescope {{x}} = x
+  instance-telescope¹⁵ :
+    { l1 l2 l3 l4 l5 l6 l7 l8 l9 l10 l11 l12 l13 l14 l15 l : Level}
+    { A1 : UU l1} {A2 : A1 → UU l2} {A3 : (x1 : A1) → A2 x1 → UU l3}
+    { A4 : (x1 : A1) (x2 : A2 x1) → A3 x1 x2 → UU l4}
+    { A5 : (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3) → UU l5}
+    { A6 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) → UU l6}
+    { A7 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5) → UU l7}
+    { A8 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) → UU l8}
+    { A9 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7) →
+      UU l9}
+    { A10 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) →
+      UU l10}
+    { A11 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9) →
+      UU l11}
+    { A12 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10) → UU l12}
+    { A13 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11) → UU l13}
+    { A14 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12) → UU l14}
+    { A15 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)
+      (x14 : A14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13) → UU l15}
+    { X :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)
+      (x14 : A14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13)
+      (x15 : A15 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14) → UU l} →
+    telescope
+      ( l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ l5 ⊔ l6 ⊔ l7 ⊔ l8 ⊔ l9 ⊔ l10 ⊔ l11 ⊔ l12 ⊔ l13 ⊔
+        l14 ⊔ l15 ⊔ l)
+      ( 15)
+  instance-telescope¹⁵ {X = X} =
+    cons-telescope (λ x → instance-telescope¹⁴ {X = X x})
+
+  instance-telescope¹⁶ :
+    { l1 l2 l3 l4 l5 l6 l7 l8 l9 l10 l11 l12 l13 l14 l15 l16 l : Level}
+    { A1 : UU l1} {A2 : A1 → UU l2} {A3 : (x1 : A1) → A2 x1 → UU l3}
+    { A4 : (x1 : A1) (x2 : A2 x1) → A3 x1 x2 → UU l4}
+    { A5 : (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3) → UU l5}
+    { A6 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) → UU l6}
+    { A7 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5) → UU l7}
+    { A8 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) → UU l8}
+    { A9 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7) →
+      UU l9}
+    { A10 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) →
+      UU l10}
+    { A11 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9) →
+      UU l11}
+    { A12 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10) → UU l12}
+    { A13 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11) → UU l13}
+    { A14 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12) → UU l14}
+    { A15 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)
+      (x14 : A14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13) → UU l15}
+    { A16 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)
+      (x14 : A14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13)
+      (x15 : A15 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14) → UU l16}
+    { X :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)
+      (x14 : A14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13)
+      (x15 : A15 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14)
+      (x16 : A16 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15) → UU l} →
+    telescope
+      ( l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ l5 ⊔ l6 ⊔ l7 ⊔ l8 ⊔ l9 ⊔ l10 ⊔ l11 ⊔ l12 ⊔ l13 ⊔
+        l14 ⊔ l15 ⊔ l16 ⊔ l)
+      ( 16)
+  instance-telescope¹⁶ {X = X} =
+    cons-telescope (λ x → instance-telescope¹⁵ {X = X x})
+
+  instance-telescope¹⁷ :
+    { l1 l2 l3 l4 l5 l6 l7 l8 l9 l10 l11 l12 l13 l14 l15 l16 l17 l : Level}
+    { A1 : UU l1} {A2 : A1 → UU l2} {A3 : (x1 : A1) → A2 x1 → UU l3}
+    { A4 : (x1 : A1) (x2 : A2 x1) → A3 x1 x2 → UU l4}
+    { A5 : (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3) → UU l5}
+    { A6 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) → UU l6}
+    { A7 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5) → UU l7}
+    { A8 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) → UU l8}
+    { A9 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7) →
+      UU l9}
+    { A10 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) →
+      UU l10}
+    { A11 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9) →
+      UU l11}
+    { A12 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10) → UU l12}
+    { A13 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11) → UU l13}
+    { A14 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12) → UU l14}
+    { A15 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)
+      (x14 : A14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13) → UU l15}
+    { A16 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)
+      (x14 : A14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13)
+      (x15 : A15 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14) → UU l16}
+    { A17 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)
+      (x14 : A14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13)
+      (x15 : A15 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14)
+      (x16 : A16 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15) → UU l17}
+    { X :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)
+      (x14 : A14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13)
+      (x15 : A15 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14)
+      (x16 : A16 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15)
+      (x17 : A17 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16) →
+      UU l} →
+    telescope
+      ( l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ l5 ⊔ l6 ⊔ l7 ⊔ l8 ⊔ l9 ⊔ l10 ⊔ l11 ⊔ l12 ⊔ l13 ⊔
+        l14 ⊔ l15 ⊔ l16 ⊔ l17 ⊔ l)
+      ( 17)
+  instance-telescope¹⁷ {X = X} =
+    cons-telescope (λ x → instance-telescope¹⁶ {X = X x})
+
+  instance-telescope¹⁸ :
+    { l1 l2 l3 l4 l5 l6 l7 l8 l9 l10 l11 l12 l13 l14 l15 l16 l17 l18 l : Level}
+    { A1 : UU l1} {A2 : A1 → UU l2} {A3 : (x1 : A1) → A2 x1 → UU l3}
+    { A4 : (x1 : A1) (x2 : A2 x1) → A3 x1 x2 → UU l4}
+    { A5 : (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3) → UU l5}
+    { A6 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) → UU l6}
+    { A7 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5) → UU l7}
+    { A8 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) → UU l8}
+    { A9 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7) →
+      UU l9}
+    { A10 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) →
+      UU l10}
+    { A11 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9) →
+      UU l11}
+    { A12 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10) → UU l12}
+    { A13 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11) → UU l13}
+    { A14 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12) → UU l14}
+    { A15 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)
+      (x14 : A14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13) → UU l15}
+    { A16 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)
+      (x14 : A14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13)
+      (x15 : A15 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14) → UU l16}
+    { A17 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)
+      (x14 : A14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13)
+      (x15 : A15 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14)
+      (x16 : A16 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15) → UU l17}
+    { A18 :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)
+      (x14 : A14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13)
+      (x15 : A15 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14)
+      (x16 : A16 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15)
+      (x17 : A17 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16) →
+      UU l18}
+    { X :
+      (x1 : A1) (x2 : A2 x1) (x3 : A3 x1 x2) (x4 : A4 x1 x2 x3)
+      (x5 : A5 x1 x2 x3 x4) (x6 : A6 x1 x2 x3 x4 x5)
+      (x7 : A7 x1 x2 x3 x4 x5 x6) (x8 : A8 x1 x2 x3 x4 x5 x6 x7)
+      (x9 : A9 x1 x2 x3 x4 x5 x6 x7 x8) (x10 : A10 x1 x2 x3 x4 x5 x6 x7 x8 x9)
+      (x11 : A11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
+      (x12 : A12 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
+      (x13 : A13 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)
+      (x14 : A14 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13)
+      (x15 : A15 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14)
+      (x16 : A16 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15)
+      (x17 : A17 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16)
+      (x18 : A18 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17) →
+      UU l} →
+    telescope
+      ( l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ l5 ⊔ l6 ⊔ l7 ⊔ l8 ⊔ l9 ⊔ l10 ⊔ l11 ⊔ l12 ⊔ l13 ⊔
+        l14 ⊔ l15 ⊔ l16 ⊔ l17 ⊔ l18 ⊔ l)
+      ( 18)
+  instance-telescope¹⁸ {X = X} =
+    cons-telescope (λ x → instance-telescope¹⁷ {X = X x})
 ```


### PR DESCRIPTION
Since the telescope instances have to be in scope for the instance arguments to work, I think it is sensible if the files that define iterated lemmas with instance arguments also export telescopes, therefore I propose moving the iterated lemmas to the files about iterated types, to somewhat contain them. This is also a natural place to look for them.